### PR TITLE
Bump rspec_junit_formatter from 0.4.1 to 0.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -386,7 +386,7 @@ GEM
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
     rspec-support (3.13.1)
-    rspec_junit_formatter (0.4.1)
+    rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.90.0)
       parallel (~> 1.10)


### PR DESCRIPTION
Bumps spec_junit_formatter from 0.4.1 to 0.6.0