### PR TITLE
fix: keep homework heading readable without dashboard image

### DIFF
--- a/app/views/shared/_homework.html.slim
+++ b/app/views/shared/_homework.html.slim
@@ -1,4 +1,6 @@
-section.page-section.text-center.homework-image id="homework" style=render_dashboard_style(@dashboard_style)
+section.page-section.text-center#homework[
+  class=("homework-image" if @dashboard_style&.image&.attached?)
+  style=render_dashboard_style(@dashboard_style)]
   .container
     h1.page-section-header.text-uppercase Homework
     ==render_small_separator


### PR DESCRIPTION
The homework section always applied the .homework-image class, whose color: white only makes sense over the dark gradient background that render_dashboard_style emits when a dashboard image is attached. With no image, the heading rendered as white text on a light background.

Apply .homework-image only when an image is attached, so the heading falls back to the default dark text otherwise.