### PR TITLE
refactor: use system_root_path as admin after-login path

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource)
-    resource.is_a?(Admin) ? system_schools_path : dashboard_path
+    resource.is_a?(Admin) ? system_root_path : dashboard_path
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {omniauth_callbacks: "users/omniauth_callbacks"}
 
   namespace :system do
+    root to: "schools#index"
+
     resources :school_groups
     resources :subjects
     resources :customisations, except: %i[show destroy]


### PR DESCRIPTION
Add a root route to the system namespace (pointing at schools#index) and redirect Admins to system_root_path after sign-in.