### PR TITLE
fix(quiz): add spacing between answer button text and result icon

### DIFF
--- a/app/javascript/controllers/multiple_choice_question_controller.js
+++ b/app/javascript/controllers/multiple_choice_question_controller.js
@@ -43,7 +43,7 @@ export default class extends Controller {
         correct = true;
         el.insertAdjacentHTML(
           "beforeend",
-          '<i class="fas fa-check fa-lg float-right my-1"></i>',
+          '<i class="fas fa-check fa-lg float-right my-1 ms-2"></i>',
         );
       }
     }
@@ -51,7 +51,7 @@ export default class extends Controller {
       guess.classList.add("incorrect-answer");
       guess.insertAdjacentHTML(
         "beforeend",
-        '<i class="fas fa-times fa-lg float-right my-1"></i>',
+        '<i class="fas fa-times fa-lg float-right my-1 ms-2"></i>',
       );
     }
   }

--- a/app/javascript/controllers/short_response_question_controller.js
+++ b/app/javascript/controllers/short_response_question_controller.js
@@ -39,7 +39,7 @@ export default class extends Controller {
       button.textContent = "Correct!";
       button.insertAdjacentHTML(
         "beforeend",
-        '<i class="fas fa-check fa-lg float-right my-1"></i>',
+        '<i class="fas fa-check fa-lg float-right my-1 ms-2"></i>',
       );
       return;
     }
@@ -48,7 +48,7 @@ export default class extends Controller {
       button.textContent = "Incorrect";
       button.insertAdjacentHTML(
         "beforeend",
-        '<i class="fas fa-times fa-lg float-right my-1"></i>',
+        '<i class="fas fa-times fa-lg float-right my-1 ms-2"></i>',
       );
       this.inputTarget.classList.add("correct-answer");
       this.inputTarget.value =


### PR DESCRIPTION
## What

The tick/cross icon shown on a button after selecting a quiz answer had no spacing from the button text — it sat flush against it.

## Why

The icon was inserted with `float-right my-1` but no horizontal margin.

## Change

Added `ms-2` (Bootstrap margin-start) to the correct (`fa-check`) and incorrect (`fa-times`) icons in both:

- `multiple_choice_question_controller.js`
- `short_response_question_controller.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)