### PR TITLE
perf(puma): preload app to share memory via copy-on-write

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,6 +36,12 @@ port ENV.fetch("PORT", 3000)
 #
 workers ENV.fetch("WEB_CONCURRENCY", 2)
 
+# Preload before forking so workers share the Rails boot via copy-on-write,
+# lowering total RSS. Rails 7.1+ re-establishes Active Record connections across
+# forks automatically, so no `on_worker_boot` hook is needed. Disables Puma's
+# in-process phased restart, which we don't use (restarts happen at the platform).
+preload_app!
+
 # Start Barnes to support Heroku runtime metrics.
 #
 before_fork { Barnes.start }


### PR DESCRIPTION
## What

Re-add `preload_app!` to `config/puma.rb`. It was dropped when the Rails 7.2 default Puma template was adopted (commit `ae76441d`), not by deliberate choice.

## Why

Preloading forks workers from a fully-booted master, so they share the Rails boot (gems, framework, eager-loaded code) via **copy-on-write** — lowering total RSS in clustered mode (~100–250 MB across our 2 workers). This matters ahead of migrating off Heroku to an environment with a **hard** memory limit, where overruns mean an OOM `SIGKILL` rather than Heroku's R14 warn-and-swap.

## Notes

- **No `on_worker_boot` reconnect hook** is reintroduced. Since Rails 7.1, Active Record re-establishes connections across forks automatically via `Process._fork` callbacks, so the old hook is obsolete.
- **Trade-off:** `preload_app!` disables Puma's in-process phased restart. We don't rely on it — restarts happen at the platform level (rolling container replacement).

## Verification

- `bundle exec standardrb config/puma.rb` — clean
- Booted Puma in `production` cluster mode: app preloads and the restart banner reports `phased (✖)`, confirming `preload_app!` is active. (Full boot needs prod S3/DB secrets; preload path itself is exercised.)

A broader memory checklist for the Render move (jemalloc, `MALLOC_ARENA_MAX`, worker recycling, Barnes removal) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)