### PR TITLE
chore: pin css_parser to 1.22

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem "simple_form"
 # Bootstrap for emails
 gem "bootstrap-email"
 gem "sass-embedded", "~> 1"
+gem "css_parser", "~> 1.22"
 
 # Dyno scaling
 gem "hirefire-resource"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
-    css_parser (1.17.1)
+    css_parser (1.22.0)
       addressable
     csv (3.3.2)
     cuprite (0.17)
@@ -584,6 +584,7 @@ DEPENDENCIES
   bullet
   bundler-audit
   capybara
+  css_parser (~> 1.22)
   csv
   cuprite
   debug


### PR DESCRIPTION
Pin css_parser (transitive via bootstrap-email -> premailer) to ~> 1.22, resolving to 1.22.0.