### PR TITLE
chore: upgrade devise to 5.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem "shakapacker", "= 10.1.0"
 gem "turbo-rails"
 
 # User authentication
-gem "devise"
+gem "devise", "~> 5.0"
 gem "devise_invitable"
 gem "omniauth"
 gem "omniauth-oauth2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,10 +183,10 @@ GEM
     delayed_job_active_record (4.1.11)
       activerecord (>= 3.0, < 9.0)
       delayed_job (>= 3.0, < 5)
-    devise (4.9.4)
+    devise (5.0.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
     devise_invitable (2.0.12)
@@ -588,7 +588,7 @@ DEPENDENCIES
   cuprite
   debug
   delayed_job_active_record
-  devise
+  devise (~> 5.0)
   devise_invitable
   dotenv
   factory_bot_rails

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -9,13 +9,6 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
-  # The secret key used by Devise. Devise uses this key to generate
-  # random tokens. Changing this key will render invalid all existing
-  # confirmation, reset password and unlock tokens in the database.
-  # Devise will use the `secret_key_base` as its `secret_key`
-  # by default. You can change it below and use your own secret key.
-  config.secret_key = ENV["DEVISE_SECRET_KEY"] || Rails.application.secret_key_base
-
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
   # config.parent_controller = 'DeviseController'


### PR DESCRIPTION
Bump devise 4.9.4 -> 5.0.4 and remove the now-redundant config.secret_key line (devise 5 defaults to secret_key_base).