### PR TITLE
fix(ui): accessibility, mobile layout, and auth page polish

### DIFF
--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -220,7 +220,7 @@ h1#branding-text {
 }
 
 // Overlay below the fixed navbar; don't displace the masthead.
-.fixed-top ~ .alert {
+.fixed-top ~ #flashes .alert {
   position: fixed;
   top: 66px;
   left: 0;

--- a/app/javascript/styles/pages.scss
+++ b/app/javascript/styles/pages.scss
@@ -48,7 +48,7 @@ body {
     url("../images/bg-masthead.jpg");
   background-size: cover;
   background-position: center;
-  background-attachment: fixed;
+  background-attachment: scroll;
   height: 100vh;
 }
 

--- a/app/views/dashboard/student_dashboard.html.slim
+++ b/app/views/dashboard/student_dashboard.html.slim
@@ -5,7 +5,7 @@ section.page-section.text-center#newQuiz
     h1.page-section-header.text-uppercase Start a Quiz
     p.lead Select a subject below
     ==render_small_separator
-    .carousel.slide.col-md-8.col-lg-5.mx-auto#subjectCarousel data-bs-ride="carousel"
+    .carousel.slide.col-md-8.col-lg-5.mx-auto#subjectCarousel data-bs-interval="false"
       ol.carousel-indicators
         - @subjects.each_with_index do |s, i|
           li data-bs-target="#subjectCarousel" data-bs-slide-to=i class=('active' if i.zero?)
@@ -13,7 +13,7 @@ section.page-section.text-center#newQuiz
         - @subjects.each_with_index do |s, i|
             .carousel-item class=('active' if i.zero?)
               a href=new_quiz_path(subject: s.name)
-                = image_pack_tag(subject_image(s), class: 'w-100 subject-carousel-item-image')
+                = image_pack_tag(subject_image(s), class: 'w-100 subject-carousel-item-image', alt: s.name)
                 .carousel-caption
                   h3.text-uppercase = s.name
       a.carousel-control-prev href="#subjectCarousel" role="button" data-bs-slide="prev"
@@ -28,7 +28,7 @@ section#challenges.page-section.text-center
     h1.page-section-header.text-uppercase Challenges
     ==render_small_separator
     .row.justify-content-center
-      .col-lg-10.col.mx-auto
+      .col-lg-10.col.mx-auto.table-responsive
         table.table.table-hover#challenge-table
           thead
             tr

--- a/app/views/dashboard/teacher_dashboard.html.slim
+++ b/app/views/dashboard/teacher_dashboard.html.slim
@@ -14,6 +14,7 @@ section.page-section.text-center#myClassrooms
               th Subject
               th.d-none.d-lg-table-cell # Students
               th
+                span.visually-hidden Actions
           tbody
             - @enrollments.each do |e|
               tr data-classroom=e.classroom.id

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,8 +1,8 @@
 header.masthead.masthead-container.masthead-full.text-white
-  .container.py-5
-    .row.justify-content-center.align-items-center
-      .col-6.text-center.bg-white.text-dark.rounded
-        h2 Log in
+  .container.min-vh-100.d-flex.flex-column.justify-content-center.py-5
+    .row.justify-content-center
+      .col-md-8.col-lg-6.text-center.bg-white.text-dark.rounded.shadow.p-4.p-md-5
+        h2.mb-4 Log in
         = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
           .form-inputs
             - if resource.class.name == 'Admin'
@@ -18,7 +18,7 @@ header.masthead.masthead-container.masthead-full.text-white
             = f.input :password,                               \
               required: false,                                 \
               input_html: { autocomplete: "current-password" }
-            = f.input :remember_me, as: :boolean if devise_mapping.rememberable?
+            = f.input :remember_me, as: :boolean, wrapper_html: { class: 'd-inline-block' } if devise_mapping.rememberable?
           .form-actions
             = f.button :submit, "Log in", class: 'btn btn-primary'
         = render "devise/shared/links"

--- a/app/views/leaderboard/show.html.slim
+++ b/app/views/leaderboard/show.html.slim
@@ -74,15 +74,18 @@
                     label.form-check-label for="allTimeSwitch" All Time
 
             .row
-              table.table#leaderboardTable
-                thead
-                  tr
-                    th #
-                    th
-                    th Name
-                    th
-                    th.d-none.d-lg-table-cell x-text="contextualHeader()"
-                    th Score
-                tbody x-html="sortedEntriesHtml()"
+              .table-responsive
+                table.table#leaderboardTable
+                  thead
+                    tr
+                      th #
+                      th
+                        span.visually-hidden Icon
+                      th Name
+                      th
+                        span.visually-hidden Awards
+                      th.d-none.d-lg-table-cell x-text="contextualHeader()"
+                      th Score
+                  tbody x-html="sortedEntriesHtml()"
 
         span#connected x-show="connected" style="display: none"

--- a/app/views/quizzes/_question_bottom.html.slim
+++ b/app/views/quizzes/_question_bottom.html.slim
@@ -11,6 +11,7 @@
           flagged_questions_path(flagged_question: {user_id: current_user.id, question_id: @question.id }),
           class: 'btn',
           id: 'unfairFlag',
+          'aria-label': 'Flag this question as unfair',
           data: { controller: 'unfair-flag', action: 'click->unfair-flag#flag' }
 
 - unless @quiz.counts_for_leaderboard

--- a/app/views/quizzes/_question_top.html.slim
+++ b/app/views/quizzes/_question_top.html.slim
@@ -9,15 +9,15 @@
     .col-3.text-center
       ul.list-inline
         li.list-inline-item
-          i.fas.fa-bolt.text-dark alt='Streak' title='Streak' data-bs-toggle="tooltip"
+          i.fas.fa-bolt.text-dark aria-label='Streak' title='Streak' data-bs-toggle="tooltip"
         li.list-inline-item#streak data-quiz-stats-target="streak" = @quiz.streak
     .col-3.text-center
       ul.list-inline
         li.list-inline-item
-          i.fas.fa-check.text-success alt='Correct' title='Correct' data-bs-toggle="tooltip"
+          i.fas.fa-check.text-success aria-label='Correct' title='Correct' data-bs-toggle="tooltip"
         li.list-inline-item#answeredCorrect data-quiz-stats-target="answeredCorrect" = @quiz.answered_correct
     .col-3.text-center
       ul.list-inline
         li.list-inline-item
-          i.fas.fa-times.text-primary alt='Multiplier' title='Multiplier' data-bs-toggle="tooltip"
+          i.fas.fa-times.text-primary aria-label='Multiplier' title='Multiplier' data-bs-toggle="tooltip"
         li.list-inline-item#multiplier data-quiz-stats-target="multiplier" = @multiplier

--- a/app/views/shared/_user_navigation.html.slim
+++ b/app/views/shared/_user_navigation.html.slim
@@ -48,11 +48,9 @@ nav#navbar-main.navbar.navbar-expand-md.navbar-dark.justify-content-between.bg-b
                 | Edit Questions
 
       - if current_user.student?
-        a href=show_available_customisations_path
-          table
-            td
-              i.fas.fa-star.f.text-warning
-            td#challenge-points.text-light = current_user.challenge_points
+        a.d-inline-flex.align-items-center.me-3 href=show_available_customisations_path aria-label="Challenge points"
+          i.fas.fa-star.text-warning.me-1 aria-hidden="true"
+          span#challenge-points.text-light = current_user.challenge_points
       p.m-2#current_user_paragraph
         a#current_user.text-light href=user_path(current_user)
           => current_user.forename


### PR DESCRIPTION
- a11y: accessible names for icon-only controls, flex span instead of layout table in navbar, alt text on carousel images, labelled empty table headers
- mobile: responsive tables, masthead background-attachment scroll, carousel autoplay disabled
- auth page: padded/centered sign-in card that grows instead of clipping on small viewports, aligned remember-me checkbox, fixed flash overlay selector