### PR TITLE
fix(system): handle validation failures on update

### DIFF
--- a/app/controllers/system/customisations_controller.rb
+++ b/app/controllers/system/customisations_controller.rb
@@ -30,9 +30,13 @@ module System
     end
 
     def update
-      customisation = authorize find_customisation
-      customisation.update(customisation_params)
-      redirect_to system_customisations_path
+      @customisation = authorize find_customisation
+
+      if @customisation.update(customisation_params)
+        redirect_to system_customisations_path
+      else
+        render :edit, status: :unprocessable_content
+      end
     end
 
     private

--- a/app/controllers/system/subjects_controller.rb
+++ b/app/controllers/system/subjects_controller.rb
@@ -31,9 +31,13 @@ module System
     end
 
     def update
-      subject = authorize find_subject
-      subject.update(subject_params)
-      redirect_to edit_system_subject_path(subject)
+      @subject = authorize find_subject
+
+      if @subject.update(subject_params)
+        redirect_to edit_system_subject_path(@subject)
+      else
+        render :edit, status: :unprocessable_content
+      end
     end
 
     def destroy

--- a/spec/requests/system/customisations_request_spec.rb
+++ b/spec/requests/system/customisations_request_spec.rb
@@ -65,5 +65,14 @@ RSpec.describe "System::Customisations", :default_creates, type: :request do
       }
       expect(customisation.reload.name).to eq("Renamed")
     end
+
+    it "does not save an invalid name" do
+      customisation = create(:customisation, name: "Original")
+      patch system_customisation_path(customisation), params: {
+        customisation: {name: ""}
+      }
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(customisation.reload.name).to eq("Original")
+    end
   end
 end

--- a/spec/requests/system/subjects_request_spec.rb
+++ b/spec/requests/system/subjects_request_spec.rb
@@ -31,6 +31,21 @@ RSpec.describe "System::Subjects", :default_creates, type: :request do
     end
   end
 
+  describe "PATCH /system/subjects/:id" do
+    it "updates a subject" do
+      subject_record = create(:subject, name: "Physics")
+      patch system_subject_path(subject_record), params: {subject: {name: "Astronomy"}}
+      expect(subject_record.reload.name).to eq("Astronomy")
+    end
+
+    it "does not save an invalid name" do
+      subject_record = create(:subject, name: "Geography")
+      patch system_subject_path(subject_record), params: {subject: {name: ""}}
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(subject_record.reload.name).to eq("Geography")
+    end
+  end
+
   describe "DELETE /system/subjects/:id" do
     it "deactivates the subject" do
       subject_record = create(:subject)


### PR DESCRIPTION
The create actions re-render the form on a failed save, but the update actions called update without checking the result and always redirected, silently discarding invalid edits (e.g. a blank or duplicate name).

Branch on the update result and re-render :edit with 422 on failure, so validation errors surface to the user — matching the create behaviour.