### PR TITLE
refactor(activerecord): fix scope, tidy queries

### DIFF
--- a/app/controllers/customisations_controller.rb
+++ b/app/controllers/customisations_controller.rb
@@ -11,7 +11,7 @@ class CustomisationsController < ApplicationController
     @purchased_styles = Customisation.with_attached_image.where(id: @bought_customisations)
     @available_styles = Customisation.with_attached_image.where(purchasable: true)
       .where.not(id: @bought_customisations)
-      .order("RANDOM()")
+      .order(Arel.sql("RANDOM()"))
   end
 
   def buy

--- a/app/controllers/leaderboard_controller.rb
+++ b/app/controllers/leaderboard_controller.rb
@@ -37,6 +37,8 @@ class LeaderboardController < ApplicationController
 
   def set_leaderboard_ajax_response_variables
     @subject = Subject.find_by(name: leaderboard_params[:id])
+    return if @subject.blank?
+
     build_leaderboard
     set_filter_data
     set_user_data

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -4,7 +4,7 @@ class Challenge < ApplicationRecord
   belongs_to :topic
   has_many :challenge_progresses, dependent: :destroy
 
-  scope :has_progress, ->(user) { includes(:challenge_progresses).where("challenge_progresses.user_id = ?", user) }
+  scope :has_progress, ->(user) { joins(:challenge_progresses).where(challenge_progresses: {user_id: user}) }
   scope :has_no_progress, -> { where.missing(:challenge_progresses) }
 
   enum :challenge_type, {number_correct: 0, streak: 1, number_of_points: 2}

--- a/app/policies/topic_policy.rb
+++ b/app/policies/topic_policy.rb
@@ -5,10 +5,9 @@ class TopicPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
+      # pluck(:id): with_role selects subjects.*, so a subquery would be multi-column.
       scope.where(active: true,
-        subject: Subject.with_role(:question_author, user)
-          .where(active: true)
-          .pluck(:id))
+        subject: Subject.with_role(:question_author, user).where(active: true).pluck(:id))
     end
   end
 

--- a/app/services/challenge/update_challenge_progress.rb
+++ b/app/services/challenge/update_challenge_progress.rb
@@ -93,7 +93,7 @@ class Challenge::UpdateChallengeProgress < ApplicationService
     Challenge.joins(:topic)
       .includes(topic: :subject)
       .where(topics: {subject_id: @quiz.subject})
-      .where("end_date > ?", Time.current)
+      .where(end_date: Time.current..)
   end
 
   def complete_challenge(progress)

--- a/app/services/homework/update_homework_progress.rb
+++ b/app/services/homework/update_homework_progress.rb
@@ -21,12 +21,12 @@ class Homework::UpdateHomeworkProgress < ApplicationCommand
   private
 
   def homework_progresses
-    HomeworkProgress.includes(:homework, :topic).where(user: @quiz.user)
+    HomeworkProgress.joins(:homework)
+      .includes(:homework)
+      .where(user: @quiz.user, homework: {topic_id: @quiz.topic})
   end
 
   def check_percentage_correct(progress)
-    return unless @quiz.topic == progress.topic
-
     check_progress_percentage(@quiz.answered_correct.to_f / @quiz.num_questions_asked, progress)
   end
 

--- a/app/services/quiz/create_quiz.rb
+++ b/app/services/quiz/create_quiz.rb
@@ -77,7 +77,7 @@ class Quiz::CreateQuiz < ApplicationCommand
       .includes(:topic).references(:topic)
       .select("questions.topic_id, questions.*")
       .where(topics: {active: true, subject_id: @subject.id})
-      .order("questions.topic_id, random()")
+      .order(Arel.sql("questions.topic_id, random()"))
   end
 
   def topic_questions
@@ -85,7 +85,7 @@ class Quiz::CreateQuiz < ApplicationCommand
       .includes(:topic).references(:topic)
       .select("DISTINCT ON(questions.topic_id) questions.topic_id, questions.*")
       .where(topics: {active: true, subject_id: @subject.id})
-      .order("questions.topic_id, random()")
+      .order(Arel.sql("questions.topic_id, random()"))
   end
 
   def lesson_questions
@@ -115,13 +115,13 @@ class Quiz::CreateQuiz < ApplicationCommand
 
   def check_lesson_attempts
     !UsageStatistic.where(user: @user, topic: @quiz.topic, lesson: @quiz.lesson, date: Date.current.all_day)
-      .where("quizzes_started >= 1")
+      .where(quizzes_started: 1..)
       .exists?
   end
 
   def check_topic_attempts
     !UsageStatistic.where(user: @user, topic: @quiz.topic, date: Date.current.all_day)
-      .where("quizzes_started >= 3")
+      .where(quizzes_started: 3..)
       .exists?
   end
 end

--- a/spec/models/challenge_spec.rb
+++ b/spec/models/challenge_spec.rb
@@ -80,6 +80,30 @@ RSpec.describe Challenge do
     end
   end
 
+  describe "scopes" do
+    let(:user) { create(:user) }
+    let!(:challenge_with_progress) { create(:challenge) }
+    let!(:challenge_without_progress) { create(:challenge) }
+
+    before { create(:challenge_progress, challenge: challenge_with_progress, user: user) }
+
+    describe ".has_progress" do
+      it "returns challenges the user has progress on" do
+        expect(described_class.has_progress(user)).to contain_exactly(challenge_with_progress)
+      end
+
+      it "ignores progress belonging to another user" do
+        expect(described_class.has_progress(create(:user))).to be_empty
+      end
+    end
+
+    describe ".has_no_progress" do
+      it "returns challenges with no progress" do
+        expect(described_class.has_no_progress).to contain_exactly(challenge_without_progress)
+      end
+    end
+  end
+
   describe "#stringify" do
     before { srand(1) }
 


### PR DESCRIPTION
- Challenge.has_progress raised PG::UndefinedTable (includes + string condition on an unjoined table); rewrite as a join, add regression specs.
- Guard the leaderboard XHR path against an unknown subject (was nil#id).
- UpdateHomeworkProgress: filter homework progresses by topic in SQL instead of loading all and filtering in Ruby.
- String comparisons -> ranges (quizzes_started, end_date); wrap bare RANDOM() orders in Arel.sql for consistency.