### PR TITLE
chore: regenerate schema.rb for Rails 7.2

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_06_08_181350) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_08_181350) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
The dump was tagged ActiveRecord::Schema[7.0] while the app runs Rails 7.2 (config.load_defaults 7.2). Regenerated via db:schema:dump so the format version matches reality. No structural changes — every column is dumped explicitly, so db:schema:load behaviour is unchanged.